### PR TITLE
Add AGENTS.md for AI coding agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,51 @@
+# AGENTS.md
+
+## Project
+
+SideButton is an open-source AI agent platform: MCP server (40+ browser tools), YAML workflow engine (34+ step types), and knowledge packs that bundle domain expertise per web app.
+
+- **Language:** TypeScript
+- **Package manager:** pnpm
+- **Monorepo layout:** `packages/` (server, core, dashboard, sidebutton)
+
+## Build & Run
+
+```bash
+pnpm install
+pnpm build
+npx sidebutton@latest   # starts server + dashboard on port 9876
+```
+
+## Code Style
+
+- TypeScript strict mode
+- ES modules
+- Conventional commits: `feat(server):`, `fix(core):`, `docs:`, etc.
+
+## Testing
+
+```bash
+pnpm test              # run all tests
+pnpm test --filter server  # test specific package
+```
+
+## Package Structure
+
+| Package | Purpose |
+|---------|---------|
+| `packages/server` | MCP server — browser tools, workflow runner, REST API |
+| `packages/core` | Shared types, utilities, workflow parser |
+| `packages/dashboard` | Web UI for workflows, run logs, settings |
+| `packages/sidebutton` | CLI entry point (`npx sidebutton@latest`) |
+
+## Key Concepts
+
+- **Knowledge packs** — markdown files bundling selectors, data models, and role playbooks per web app
+- **Workflows** — YAML files with steps (navigate, click, type, extract, LLM, shell, control flow)
+- **Skill resources** — served via MCP `skill://` URIs for AI agent consumption
+- **Browser tools** — snapshot, screenshot, click, type, fill, navigate, evaluate, etc.
+
+## Security
+
+- Never commit secrets or credentials
+- See SECURITY.md for vulnerability reporting


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` file following the [agents.md](https://agents.md) open format
- Helps AI coding agents (Codex, Claude Code, Cursor, Devin) understand project structure, build commands, code style, and key concepts
- Part of the growing AGENTS.md standard now stewarded by the Agentic AI Foundation (Linux Foundation)

## Test plan
- [ ] Verify AGENTS.md renders correctly on GitHub
- [ ] Confirm AI coding agents can parse the file for project context

Ref: SCRUM-479

🤖 Generated with [Claude Code](https://claude.com/claude-code)