### PR TITLE
Add AGENTS.md for AI coding agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,59 @@
+# AGENTS.md
+
+## Project
+
+SideButton is an open-source AI agent platform: MCP server with browser tools, YAML workflow engine, and knowledge packs that bundle domain expertise per web app.
+
+- **Language:** TypeScript
+- **Package manager:** pnpm
+- **Monorepo layout:** `packages/` (server, core, dashboard, sidebutton)
+
+## Build & Run
+
+**Quick start (published package, no clone needed):**
+
+```bash
+npx sidebutton@latest   # starts server + dashboard on port 9876
+```
+
+**Local development:**
+
+```bash
+pnpm install
+pnpm build
+pnpm start               # or: pnpm dev
+```
+
+## Code Style
+
+- TypeScript strict mode
+- ES modules
+
+## Testing
+
+```bash
+pnpm test              # run all tests
+pnpm test --filter server  # test specific package
+```
+
+## Package Structure
+
+| Package | Purpose |
+|---------|---------|
+| `packages/server` | MCP server — browser tools, workflow runner, REST API |
+| `packages/core` | Workflow engine, step executors, shared types |
+| `packages/dashboard` | Web UI for workflows, run logs, settings |
+| `packages/sidebutton` | CLI entry point (`npx sidebutton@latest`) |
+| `extension/` | Chrome extension (Manifest V3) — distributed via Chrome Web Store |
+
+## Key Concepts
+
+- **Knowledge packs** — markdown files bundling selectors, data models, and role playbooks per web app
+- **Workflows** — YAML files with steps (navigate, click, type, extract, LLM, shell, control flow)
+- **Skill resources** — served via MCP `skill://` URIs for AI agent consumption
+- **Browser tools** — snapshot, screenshot, click, type, fill, navigate, evaluate, etc.
+
+## Security
+
+- Never commit secrets or credentials
+- See SECURITY.md for vulnerability reporting


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` to help AI coding agents understand project structure
- Separates quick-start (`npx sidebutton@latest`) from local dev (`pnpm install/build/start`)
- Corrects `packages/core` description (workflow engine, not just shared types)
- Includes `extension/` in package table

## Changes from previous PR (#58)
- **Fixed**: Build & Run no longer mixes two independent paths into one block
- **Fixed**: `packages/core` described as "Workflow engine, step executors, shared types"
- **Fixed**: Removed unverified "conventional commits" claim (no commitlint config)
- **Added**: `extension/` row in package table
- **Removed**: Specific tool/step counts that may drift out of date

## Test plan
- [ ] Verify AGENTS.md renders correctly on GitHub
- [ ] Confirm AI coding agents can parse the file for project context

Ref: SCRUM-479

🤖 Generated with [Claude Code](https://claude.com/claude-code)