### PR TITLE
fix(seo): add websiteUrl and title to server.json

### DIFF
--- a/packages/server/server.json
+++ b/packages/server/server.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.sidebutton/sidebutton",
+  "title": "SideButton MCP Server",
   "description": "Open-source MCP server with browser automation and knowledge packs for AI agents",
+  "websiteUrl": "https://sidebutton.com",
   "repository": {
     "url": "https://github.com/sidebutton/sidebutton",
     "source": "github"


### PR DESCRIPTION
## Summary
- Adds `websiteUrl: "https://sidebutton.com"` to server.json — PulseMCP currently infers provider URL as sidebutton.ai because this field was missing
- Adds `title: "SideButton MCP Server"` — display name for MCP directories, aligns with SEO target keyword

## Context
PulseMCP auto-ingests from the MCP registry server.json. Without `websiteUrl`, it guesses the provider site as sidebutton.ai. The `title` field (per MCP server schema) provides a human-readable display name that directories can use instead of the reverse-DNS `name`.

## Test plan
- [ ] Verify server.json validates against MCP schema
- [ ] After npm publish, check PulseMCP re-indexes with correct provider URL
- [ ] Verify title shows as "SideButton MCP Server" on directory listings

🤖 Generated with [Claude Code](https://claude.com/claude-code)