### PR TITLE
feat(SCRUM-812): expose compactions in /health

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -527,6 +527,7 @@ export interface HealthResponse {
   cooldown?: { until_ms: number; workflow_id: string } | null;
   claude_running?: boolean;
   claude_sessions?: { pid: number; cmd: string }[];
+  compactions?: { count: number; last_at?: string } | null;
   dependency_versions?: {
     claude_code?: string;
     node?: string;

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -1474,6 +1474,16 @@ export async function startServer(config: ServerConfig): Promise<void> {
       if (lastTool) response.last_tool_use = lastTool;
     } catch { /* no last tool use marker */ }
 
+    // Claude Code auto-compaction counter (SCRUM-812). Written by the PreCompact
+    // hook so operators can see when a job's context overflowed (quality signal).
+    try {
+      const compactData = fs.readFileSync(path.join(sidebuttonDir, 'compact-marker.json'), 'utf8');
+      const parsed = JSON.parse(compactData);
+      if (typeof parsed?.count === 'number' && parsed.count > 0) {
+        response.compactions = { count: parsed.count, last_at: parsed.last_at };
+      }
+    } catch { /* no compact marker */ }
+
     // Enumerate Claude Code processes with PIDs and command lines.
     // This lets the orchestrator track individual sessions, distinguish dispatched
     // jobs from operator debugging sessions, and detect zombie/stalled PIDs.
@@ -1559,7 +1569,7 @@ export async function startServer(config: ServerConfig): Promise<void> {
 
   // Clear file-based markers (called by Temporal before dispatching a new job)
   fastify.post('/api/clear-markers', async () => {
-    const markers = ['idle-marker', 'result-marker.json', 'last-tool-use'];
+    const markers = ['idle-marker', 'result-marker.json', 'last-tool-use', 'compact-marker.json'];
     for (const marker of markers) {
       try { fs.unlinkSync(path.join(sidebuttonDir, marker)); } catch { /* doesn't exist */ }
     }


### PR DESCRIPTION
## Summary
Mirrors the source-of-truth changes from `maxsv0/the-assistant` (synced into this OSS repo via `sync-oss.sh`). Adds Claude Code auto-compaction detection support to the server side:

- `HealthResponse.compactions: { count: number; last_at?: string } | null`
- `/health` reads `~/.sidebutton/compact-marker.json` and surfaces it
- `/api/clear-markers` now includes `compact-marker.json` so each new dispatch starts clean

The hook script and orchestrator-side changes live in the private repo (`maxsv0/the-assistant`).

## Source-of-truth PR
https://github.com/maxsv0/the-assistant/pull/400

## Files
- `packages/core/src/types.ts`
- `packages/server/src/server.ts`

## Test plan
- [ ] `pnpm build` succeeds across `packages/*` workspaces.
- [ ] With `~/.sidebutton/compact-marker.json` containing `{"count":3,"last_at":"…"}`, `curl http://localhost:9876/health | jq .compactions` returns the same object.
- [ ] Calling `POST /api/clear-markers` removes the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)